### PR TITLE
Add option to run swagger testing UI in Docker

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -19,6 +19,8 @@ ADD docker/api/healthcheck.sh /app/healthcheck.sh
 ADD docker/api/run-gunicorn.sh /app/run-gunicorn.sh
 ADD docker/docker-entrypoint.sh /docker-entrypoint.sh
 
+ENV TESTING_UI="False"
+
 EXPOSE 80
 WORKDIR /app
 HEALTHCHECK --interval=59m --timeout=5s CMD /app/healthcheck.sh

--- a/docker/api/run-gunicorn.sh
+++ b/docker/api/run-gunicorn.sh
@@ -13,4 +13,4 @@ done
 /venv/bin/gunicorn \
   --workers="${GUNICORN_WORKERS}" \
   --bind="0.0.0.0:80" \
-  "server:build_app(apis=['${api_spec}','${healthcheck_spec}'], server='tornado')"
+  "server:build_app(apis=['${api_spec}','${healthcheck_spec}'], server='tornado', ui=${TESTING_UI})"


### PR DESCRIPTION
The testing UI is enabled by setting the `TESTING_UI="True"` environment variable.

Resolves https://github.com/ascoderu/opwen-cloudserver/issues/50