### PR TITLE
Fix data issues in webapp index

### DIFF
--- a/opwen_email_server/integration/webapp.py
+++ b/opwen_email_server/integration/webapp.py
@@ -227,7 +227,6 @@ class AzureEmailStore(EmailStore, LogMixin):
                 continue
 
             self._mailbox_storage.delete(f"{domain}/{email_address}/{folder}/{email['sent_at']}/{uid}")
-            self._email_storage.delete(uid)
 
     def _mark_sent(self, uids: Iterable[str]):
         pass


### PR DESCRIPTION
If an email is sent to more than one Lokole client, having one client delete the email from the email storage (as opposed to only the client's mailbox index) causes issues for the other clients' mailbox indices.