### PR TITLE
Add auto formatting for shell scripts

### DIFF
--- a/docker/app/run-gunicorn.sh
+++ b/docker/app/run-gunicorn.sh
@@ -5,7 +5,7 @@ declare -a api_spec_paths
 case "${CONNEXION_SPEC}" in
   file:*)
     specs="${CONNEXION_SPEC:5}"
-    IFS="," read -r -a api_spec_paths <<< "${specs}"
+    IFS="," read -r -a api_spec_paths <<<"${specs}"
     ;;
   dir:*)
     specs="${CONNEXION_SPEC:4}"

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -26,6 +26,14 @@ RUN wget -q https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_V
   && rm kubeval-linux-amd64.tar.gz \
   && kubeval --version
 
+ARG SHFMT_VERSION=3.1.1
+RUN wget -q https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64 \
+  && mv shfmt_v${SHFMT_VERSION}_linux_amd64 shfmt \
+  && cp shfmt /usr/local/bin \
+  && rm shfmt \
+  && chmod +x /usr/local/bin/shfmt \
+  && shfmt -version
+
 COPY docker/ci/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -68,3 +68,5 @@ RUN helm lint --strict ./helm/opwen_cloudserver \
  && helm template ./helm/opwen_cloudserver > helm.yaml \
  && kubeval --ignore-missing-schemas helm.yaml \
  && rm helm.yaml
+
+RUN shfmt -d -i 2 -ci .

--- a/docker/integtest/0-wait-for-services.sh
+++ b/docker/integtest/0-wait-for-services.sh
@@ -31,10 +31,10 @@ wait_for_appinsights() {
   for i in $(seq 1 "${max_retries}"); do
     if [[ \
       "$(az storage container exists \
-      --name "${APPINSIGHTS_INSTRUMENTATIONKEY}" \
-      --connection-string "$(az_connection_string)" \
-      --output tsv)" = "True" \
-   ]]; then
+        --name "${APPINSIGHTS_INSTRUMENTATIONKEY}" \
+        --connection-string "$(az_connection_string)" \
+        --output tsv)" = "True" ]] \
+        ; then
       log "Appinsights is running"
       return
     fi

--- a/docker/integtest/1-register-client.sh
+++ b/docker/integtest/1-register-client.sh
@@ -40,13 +40,19 @@ if REGISTRATION_CREDENTIALS="baduser:badpassword" authenticated_request \
   "http://nginx:8888/api/email/register/" \
   -H "Content-Type: application/json" \
   -d '{"domain":"hacker.lokole.ca"}' \
-; then echo "Was able to register a client with bad basic auth credentials" >&2; exit 4; fi
+  ; then
+  echo "Was able to register a client with bad basic auth credentials" >&2
+  exit 4
+fi
 
 if REGISTRATION_CREDENTIALS="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" authenticated_request \
   "http://nginx:8888/api/email/register/" \
   -H "Content-Type: application/json" \
   -d '{"domain":"hacker.lokole.ca"}' \
-; then echo "Was able to register a client with bad bearer credentials" >&2; exit 4; fi
+  ; then
+  echo "Was able to register a client with bad bearer credentials" >&2
+  exit 4
+fi
 
 # also register another client to simulate multi-client emails
 authenticated_request \
@@ -68,7 +74,10 @@ if authenticated_request \
   "http://nginx:8888/api/email/register/" \
   -H "Content-Type: application/json" \
   -d '{"domain":"developer3.lokole.ca"}' \
-; then echo "Was able to register a duplicate client" >&2; exit 5; fi
+  ; then
+  echo "Was able to register a duplicate client" >&2
+  exit 5
+fi
 
 authenticated_request \
   "http://nginx:8888/api/email/register/developer3.lokole.ca" \

--- a/docker/integtest/2-client-uploads-emails.sh
+++ b/docker/integtest/2-client-uploads-emails.sh
@@ -11,8 +11,8 @@ mkdir -p "${out_dir}"
 emails_to_send="${in_dir}/client-emails.tar.gz"
 tar -czf "${emails_to_send}" -C "${in_dir}" emails.jsonl zzusers.jsonl
 
-client_id="$(jq -r '.client_id' < "${out_dir}/register1.json")"
-resource_container="$(jq -r '.resource_container' < "${out_dir}/register1.json")"
+client_id="$(jq -r '.client_id' <"${out_dir}/register1.json")"
+resource_container="$(jq -r '.resource_container' <"${out_dir}/register1.json")"
 resource_id="$(uuidgen).tar.gz"
 
 # workflow 1: send emails written on the client to the world

--- a/docker/integtest/3-receive-email-for-client.sh
+++ b/docker/integtest/3-receive-email-for-client.sh
@@ -13,7 +13,7 @@ email_to_receive="${in_dir}/inbound-email.mime"
 if [[ -n "$1" ]]; then
   client_id="$1"
 else
-  client_id="$(jq -r '.client_id' < "${out_dir}/register1.json")"
+  client_id="$(jq -r '.client_id' <"${out_dir}/register1.json")"
 fi
 
 # workflow 2a: receive an email directed at one of the clients

--- a/docker/integtest/4-client-downloads-emails.sh
+++ b/docker/integtest/4-client-downloads-emails.sh
@@ -13,33 +13,33 @@ num_emails_expected_for_client[2]=1
 
 for i in 1 2; do
 
-client_id="$(jq -r '.client_id' < "${out_dir}/register${i}.json")"
-resource_container="$(jq -r '.resource_container' < "${out_dir}/register${i}.json")"
+  client_id="$(jq -r '.client_id' <"${out_dir}/register${i}.json")"
+  resource_container="$(jq -r '.resource_container' <"${out_dir}/register${i}.json")"
 
-# workflow 2b: deliver emails written by the world to a lokole client
-# first the client makes a request to ask the server to package up all the
-# emails sent from the world to the client during the last period; the server
-# will package up the emails and store them on the shared blob storage
-curl -fs \
-  -H "Accept: application/json" \
-  "http://nginx:8888/api/email/download/${client_id}" \
-| tee "${out_dir}/download${i}.json"
+  # workflow 2b: deliver emails written by the world to a lokole client
+  # first the client makes a request to ask the server to package up all the
+  # emails sent from the world to the client during the last period; the server
+  # will package up the emails and store them on the shared blob storage
+  curl -fs \
+    -H "Accept: application/json" \
+    "http://nginx:8888/api/email/download/${client_id}" |
+    tee "${out_dir}/download${i}.json"
 
-resource_id="$(jq -r '.resource_id' < "${out_dir}/download${i}.json")"
+  resource_id="$(jq -r '.resource_id' <"${out_dir}/download${i}.json")"
 
-# now we simulate the client downloading the package from the shared blob storage
-az_storage download "${resource_container}" "${resource_id}" "${out_dir}/downloaded${i}.tar.gz"
+  # now we simulate the client downloading the package from the shared blob storage
+  az_storage download "${resource_container}" "${resource_id}" "${out_dir}/downloaded${i}.tar.gz"
 
-tar xzf "${out_dir}/downloaded${i}.tar.gz" -C "${out_dir}"
+  tar xzf "${out_dir}/downloaded${i}.tar.gz" -C "${out_dir}"
 
-num_emails_actual="$(wc -l "${out_dir}/emails.jsonl" | cut -d' ' -f1)"
-num_emails_expected="${num_emails_expected_for_client[${i}]}"
+  num_emails_actual="$(wc -l "${out_dir}/emails.jsonl" | cut -d' ' -f1)"
+  num_emails_expected="${num_emails_expected_for_client[${i}]}"
 
-if [[ "${num_emails_actual}" -ne "${num_emails_expected}" ]]; then
-  echo "Got ${num_emails_actual} emails but expected ${num_emails_expected}" >&2
-  exit 1
-fi
+  if [[ "${num_emails_actual}" -ne "${num_emails_expected}" ]]; then
+    echo "Got ${num_emails_actual} emails but expected ${num_emails_expected}" >&2
+    exit 1
+  fi
 
-rm "${out_dir}/emails.jsonl"
+  rm "${out_dir}/emails.jsonl"
 
 done

--- a/docker/integtest/6-receive-service-email.sh
+++ b/docker/integtest/6-receive-service-email.sh
@@ -10,7 +10,6 @@ mkdir -p "${out_dir}"
 
 email_to_receive="${in_dir}/service-email.mime"
 
-
 #receive an email directed at the service endpoint
 http --check-status -f POST \
   "http://nginx:8888/api/email/sendgrid/service" \

--- a/docker/integtest/utils.sh
+++ b/docker/integtest/utils.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 get_container() {
-  docker ps --format  '{{.Names}}' | grep "$1"
+  docker ps --format '{{.Names}}' | grep "$1"
 }
 
 log() {
@@ -10,7 +10,8 @@ log() {
 }
 
 authenticated_request() {
-  local endpoint="$1"; shift
+  local endpoint="$1"
+  shift
 
   if [[ "${REGISTRATION_CREDENTIALS}" =~ ^[^:]+:.*$ ]]; then
     curl -fs "${endpoint}" -u "${REGISTRATION_CREDENTIALS}" "$@"
@@ -38,7 +39,7 @@ az_storage() {
     --name "${blob}" \
     --container-name "${container}" \
     --connection-string "$(az_connection_string)" \
-  > /dev/null
+    >/dev/null
 }
 
 wait_seconds() {

--- a/docker/nginx/run-nginx.sh
+++ b/docker/nginx/run-nginx.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-mo < /app/nginx.conf.mustache > /app/nginx.conf
-mo < /app/server.conf.mustache > /etc/nginx/sites-enabled/server.conf
+mo </app/nginx.conf.mustache >/app/nginx.conf
+mo </app/server.conf.mustache >/etc/nginx/sites-enabled/server.conf
 
 exec nginx -c "/app/nginx.conf" -p "${PWD}" -g "daemon off;"

--- a/docker/setup/setup.sh
+++ b/docker/setup/setup.sh
@@ -61,24 +61,24 @@ az configure --defaults location="${LOCATION}"
 #
 if [[ "${DEPLOY_SERVICES}" != "no" ]]; then
 
-required_env "${scriptname}" "RESOURCE_GROUP_NAME"
+  required_env "${scriptname}" "RESOURCE_GROUP_NAME"
 
-use_resource_group "${RESOURCE_GROUP_NAME}"
+  use_resource_group "${RESOURCE_GROUP_NAME}"
 
-storageaccountsku="${STORAGE_ACCOUNT_SKU:-Standard_GRS}"
-servicebussku="${SERVICE_BUS_SKU:-Basic}"
-deploymentname="opwendeployment$(generate_identifier 8)"
+  storageaccountsku="${STORAGE_ACCOUNT_SKU:-Standard_GRS}"
+  servicebussku="${SERVICE_BUS_SKU:-Basic}"
+  deploymentname="opwendeployment$(generate_identifier 8)"
 
-log "Creating resources via deployment ${deploymentname}"
+  log "Creating resources via deployment ${deploymentname}"
 
-az group deployment create \
-  --name "${deploymentname}" \
-  --template-file "${scriptdir}/arm.template.json" \
-  --parameters storageAccountSKU="${storageaccountsku}" \
-  --parameters serviceBusSKU="${servicebussku}" \
-> /tmp/deployment.json
+  az group deployment create \
+    --name "${deploymentname}" \
+    --template-file "${scriptdir}/arm.template.json" \
+    --parameters storageAccountSKU="${storageaccountsku}" \
+    --parameters serviceBusSKU="${servicebussku}" \
+    >/tmp/deployment.json
 
-cat > /secrets/azure.env << EOF
+  cat >/secrets/azure.env <<EOF
 RESOURCE_GROUP=${RESOURCE_GROUP_NAME}
 LOKOLE_EMAIL_SERVER_APPINSIGHTS_KEY=$(jq -r .properties.outputs.appinsightsKey.value /tmp/deployment.json)
 LOKOLE_CLIENT_AZURE_STORAGE_KEY=$(jq -r .properties.outputs.clientBlobsKey.value /tmp/deployment.json)
@@ -105,37 +105,37 @@ fi
 #
 if [[ "${DEPLOY_COMPUTE}" != "no" ]]; then
 
-if [[ -z "${KUBERNETES_RESOURCE_GROUP_NAME}" ]] || [[ -z "${KUBERNETES_NODE_COUNT}" ]] || [[ -z "${KUBERNETES_NODE_SKU}" ]] || [[ -z "${KUBERNETES_VERSION}" ]]; then
-  log "Skipping production deployment to kubernetes since KUBERNETES_RESOURCE_GROUP_NAME, KUBERNETES_NODE_COUNT, or KUBERNETES_NODE_SKU, or KUBERNETES_VERSION are not set"
-  exit 0
-fi
+  if [[ -z "${KUBERNETES_RESOURCE_GROUP_NAME}" ]] || [[ -z "${KUBERNETES_NODE_COUNT}" ]] || [[ -z "${KUBERNETES_NODE_SKU}" ]] || [[ -z "${KUBERNETES_VERSION}" ]]; then
+    log "Skipping production deployment to kubernetes since KUBERNETES_RESOURCE_GROUP_NAME, KUBERNETES_NODE_COUNT, or KUBERNETES_NODE_SKU, or KUBERNETES_VERSION are not set"
+    exit 0
+  fi
 
-k8sname="opwencluster$(generate_identifier 8)"
-helmname="opwenserver$(generate_identifier 8)"
+  k8sname="opwencluster$(generate_identifier 8)"
+  helmname="opwenserver$(generate_identifier 8)"
 
-log "Creating kubernetes v${KUBERNETES_VERSION} cluster ${k8sname}"
+  log "Creating kubernetes v${KUBERNETES_VERSION} cluster ${k8sname}"
 
-use_resource_group "${KUBERNETES_RESOURCE_GROUP_NAME}"
+  use_resource_group "${KUBERNETES_RESOURCE_GROUP_NAME}"
 
-az provider register --wait --namespace Microsoft.Network
-az provider register --wait --namespace Microsoft.Storage
-az provider register --wait --namespace Microsoft.Compute
-az provider register --wait --namespace Microsoft.ContainerService
+  az provider register --wait --namespace Microsoft.Network
+  az provider register --wait --namespace Microsoft.Storage
+  az provider register --wait --namespace Microsoft.Compute
+  az provider register --wait --namespace Microsoft.ContainerService
 
-az aks create \
-  --kubernetes-version "${KUBERNETES_VERSION}" \
-  --service-principal "${SP_APPID}" \
-  --client-secret "${SP_PASSWORD}" \
-  --name "${k8sname}" \
-  --node-count "${KUBERNETES_NODE_COUNT}" \
-  --node-vm-size "${KUBERNETES_NODE_SKU}" \
-  --generate-ssh-keys
+  az aks create \
+    --kubernetes-version "${KUBERNETES_VERSION}" \
+    --service-principal "${SP_APPID}" \
+    --client-secret "${SP_PASSWORD}" \
+    --name "${k8sname}" \
+    --node-count "${KUBERNETES_NODE_COUNT}" \
+    --node-vm-size "${KUBERNETES_NODE_SKU}" \
+    --generate-ssh-keys
 
-az aks get-credentials --name "${k8sname}"
+  az aks get-credentials --name "${k8sname}"
 
-log "Setting up helm in cluster ${k8sname}"
+  log "Setting up helm in cluster ${k8sname}"
 
-kubectl apply -f- <<< "
+  kubectl apply -f- <<<"
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -155,86 +155,92 @@ subjects:
     name: tiller
     namespace: kube-system
 "
-helm_init
+  helm_init
 
-log "Setting up cert-manager v${CERT_MANAGER_VERSION} in cluster ${k8sname}"
+  log "Setting up cert-manager v${CERT_MANAGER_VERSION} in cluster ${k8sname}"
 
-kubectl apply -f "https://raw.githubusercontent.com/jetstack/cert-manager/v${CERT_MANAGER_VERSION}/deploy/manifests/00-crds.yaml"
-kubectl create namespace cert-manager
-kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-helm install --name cert-manager --namespace cert-manager --version "v${CERT_MANAGER_VERSION}" jetstack/cert-manager --wait
+  kubectl apply -f "https://raw.githubusercontent.com/jetstack/cert-manager/v${CERT_MANAGER_VERSION}/deploy/manifests/00-crds.yaml"
+  kubectl create namespace cert-manager
+  kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+  helm repo add jetstack https://charts.jetstack.io
+  helm repo update
+  helm install --name cert-manager --namespace cert-manager --version "v${CERT_MANAGER_VERSION}" jetstack/cert-manager --wait
 
-log "Setting up nginx-ingress in cluster ${k8sname}"
+  log "Setting up nginx-ingress in cluster ${k8sname}"
 
-helm repo add nginx-stable https://helm.nginx.com/stable
-helm repo update
-helm install --name nginx-ingress --version "${NGINX_INGRESS_VERSION}" nginx-stable/nginx-ingress --set controller.replicaCount=3
+  helm repo add nginx-stable https://helm.nginx.com/stable
+  helm repo update
+  helm install --name nginx-ingress --version "${NGINX_INGRESS_VERSION}" nginx-stable/nginx-ingress --set controller.replicaCount=3
 
-log "Setting up kubernetes secrets for ${k8sname}"
+  log "Setting up kubernetes secrets for ${k8sname}"
 
-kubectl create secret generic "azure" --from-env-file "/secrets/azure.env"
-kubectl create secret generic "cloudflare" --from-env-file "/secrets/cloudflare.env"
-kubectl create secret generic "users" --from-env-file "/secrets/users.env"
-kubectl create secret generic "sendgrid" --from-env-file "/secrets/sendgrid.env"
+  kubectl create secret generic "azure" --from-env-file "/secrets/azure.env"
+  kubectl create secret generic "cloudflare" --from-env-file "/secrets/cloudflare.env"
+  kubectl create secret generic "users" --from-env-file "/secrets/users.env"
+  kubectl create secret generic "sendgrid" --from-env-file "/secrets/sendgrid.env"
 
-log "Installing application in ${k8sname}"
+  log "Installing application in ${k8sname}"
 
-k8simageregistry="${KUBERNETES_IMAGE_REGISTRY:-ascoderu}"
-k8sdockertag="${KUBERNETES_DOCKER_TAG:-latest}"
-lokole_dns_name="${LOKOLE_DNS_NAME:-mailserver.lokole.ca}"
+  k8simageregistry="${KUBERNETES_IMAGE_REGISTRY:-ascoderu}"
+  k8sdockertag="${KUBERNETES_DOCKER_TAG:-latest}"
+  lokole_dns_name="${LOKOLE_DNS_NAME:-mailserver.lokole.ca}"
 
-while :; do
-  helm install \
-    --name "${helmname}" \
-    --set domain="${lokole_dns_name}" \
-    --set version.imageRegistry="${k8simageregistry}" \
-    --set version.dockerTag="${k8sdockertag}" \
-    "${scriptdir}/helm/opwen_cloudserver"
+  while :; do
+    helm install \
+      --name "${helmname}" \
+      --set domain="${lokole_dns_name}" \
+      --set version.imageRegistry="${k8simageregistry}" \
+      --set version.dockerTag="${k8sdockertag}" \
+      "${scriptdir}/helm/opwen_cloudserver"
 
-  # shellcheck disable=SC2181
-  if [[ "$?" -ne 0 ]]; then log "Intermittent error for ${helmname}"; sleep 30s; else break; fi
-done
+    # shellcheck disable=SC2181
+    if [[ "$?" -ne 0 ]]; then
+      log "Intermittent error for ${helmname}"
+      sleep 30s
+    else break; fi
+  done
 
-while :; do
-  ingressip="$(kubectl get service --selector app.kubernetes.io/instance=nginx-ingress --output jsonpath={..ip})"
-  if [[ -z "${ingressip}" ]]; then log "Waiting for ${k8sname} public IP"; sleep 30s; else break; fi
-done
+  while :; do
+    ingressip="$(kubectl get service --selector app.kubernetes.io/instance=nginx-ingress --output jsonpath={..ip})"
+    if [[ -z "${ingressip}" ]]; then
+      log "Waiting for ${k8sname} public IP"
+      sleep 30s
+    else break; fi
+  done
 
-cp ~/.kube/config /secrets/kube-config
-cp ~/.ssh/id_rsa.pub /secrets/kube-id_rsa.pub
-cp ~/.ssh/id_rsa /secrets/kube-id_rsa
+  cp ~/.kube/config /secrets/kube-config
+  cp ~/.ssh/id_rsa.pub /secrets/kube-id_rsa.pub
+  cp ~/.ssh/id_rsa /secrets/kube-id_rsa
 
-log "Setting up DNS for ${ingressip}"
+  log "Setting up DNS for ${ingressip}"
 
-cloudflare_zone="$(get_dotenv '/secrets/cloudflare.env' 'LOKOLE_CLOUDFLARE_ZONE')"
-cloudflare_user="$(get_dotenv '/secrets/cloudflare.env' 'LOKOLE_CLOUDFLARE_USER')"
-cloudflare_key="$(get_dotenv '/secrets/cloudflare.env' 'LOKOLE_CLOUDFLARE_KEY')"
-cloudflare_dns_api="https://api.cloudflare.com/client/v4/zones/${cloudflare_zone}/dns_records"
+  cloudflare_zone="$(get_dotenv '/secrets/cloudflare.env' 'LOKOLE_CLOUDFLARE_ZONE')"
+  cloudflare_user="$(get_dotenv '/secrets/cloudflare.env' 'LOKOLE_CLOUDFLARE_USER')"
+  cloudflare_key="$(get_dotenv '/secrets/cloudflare.env' 'LOKOLE_CLOUDFLARE_KEY')"
+  cloudflare_dns_api="https://api.cloudflare.com/client/v4/zones/${cloudflare_zone}/dns_records"
 
-cloudflare_cname_id="$(curl -sX GET "${cloudflare_dns_api}?type=A&name=${lokole_dns_name}" \
-  -H "X-Auth-Email: ${cloudflare_user}" \
-  -H "X-Auth-Key: ${cloudflare_key}" \
-| jq -r '.result[0].id')"
-
-if [[ -n "${cloudflare_cname_id}" ]] && [[ ${cloudflare_cname_id} != "null" ]]; then
-  curl -sX PUT "${cloudflare_dns_api}/${cloudflare_cname_id}" \
+  cloudflare_cname_id="$(curl -sX GET "${cloudflare_dns_api}?type=A&name=${lokole_dns_name}" \
     -H "X-Auth-Email: ${cloudflare_user}" \
-    -H "X-Auth-Key: ${cloudflare_key}" \
-    -H "Content-Type: application/json" \
-    -d '{"type":"A","name":"'"${lokole_dns_name}"'","content":"'"${ingressip}"'","ttl":1,"proxied":false}'
-else
-  curl -sX POST "${cloudflare_dns_api}" \
-    -H "X-Auth-Email: ${cloudflare_user}" \
-    -H "X-Auth-Key: ${cloudflare_key}" \
-    -H "Content-Type: application/json" \
-    -d '{"type":"A","name":"'"${lokole_dns_name}"'","content":"'"${ingressip}"'","ttl":1,"proxied":false}'
-fi
+    -H "X-Auth-Key: ${cloudflare_key}" |
+    jq -r '.result[0].id')"
 
-./renew-cert.sh
+  if [[ -n "${cloudflare_cname_id}" ]] && [[ ${cloudflare_cname_id} != "null" ]]; then
+    curl -sX PUT "${cloudflare_dns_api}/${cloudflare_cname_id}" \
+      -H "X-Auth-Email: ${cloudflare_user}" \
+      -H "X-Auth-Key: ${cloudflare_key}" \
+      -H "Content-Type: application/json" \
+      -d '{"type":"A","name":"'"${lokole_dns_name}"'","content":"'"${ingressip}"'","ttl":1,"proxied":false}'
+  else
+    curl -sX POST "${cloudflare_dns_api}" \
+      -H "X-Auth-Email: ${cloudflare_user}" \
+      -H "X-Auth-Key: ${cloudflare_key}" \
+      -H "Content-Type: application/json" \
+      -d '{"type":"A","name":"'"${lokole_dns_name}"'","content":"'"${ingressip}"'","ttl":1,"proxied":false}'
+  fi
 
-cat > /secrets/kubedeployment.env << EOF
+  ./renew-cert.sh
+
+  cat >/secrets/kubedeployment.env <<EOF
 RESOURCE_GROUP=${KUBERNETES_RESOURCE_GROUP_NAME}
 HELM_NAME=${helmname}
 APP_IP=${ingressip}

--- a/docker/setup/upgrade-vm.sh
+++ b/docker/setup/upgrade-vm.sh
@@ -26,4 +26,4 @@ required_env "${scriptname}" "LOKOLE_DNS_NAME"
 
 log "Upgrading VM ${LOKOLE_DNS_NAME}"
 
-exec sshpass -p "${LOKOLE_VM_PASSWORD}" ssh -o StrictHostKeyChecking=no "opwen@${LOKOLE_DNS_NAME}" < "${scriptdir}/vm.sh"
+exec sshpass -p "${LOKOLE_VM_PASSWORD}" ssh -o StrictHostKeyChecking=no "opwen@${LOKOLE_DNS_NAME}" <"${scriptdir}/vm.sh"

--- a/docker/setup/utils.sh
+++ b/docker/setup/utils.sh
@@ -42,7 +42,7 @@ required_file() {
 generate_identifier() {
   local length="$1"
 
-  < /dev/urandom tr -dc 'a-z0-9' | head -c"${length}"
+  tr </dev/urandom -dc 'a-z0-9' | head -c"${length}"
 }
 
 get_dotenv() {

--- a/docker/setup/vm.sh
+++ b/docker/setup/vm.sh
@@ -26,7 +26,7 @@ contact_email="ascoderu.opwen@gmail.com"
 sudo apt-get update
 sudo apt-get upgrade -y
 sudo apt-get install -y git curl fail2ban
-sudo tee /etc/fail2ban/jail.conf << EOM
+sudo tee /etc/fail2ban/jail.conf <<EOM
 [DEFAULT]
 ignoreip = 127.0.0.1
 bantime = 300
@@ -68,7 +68,7 @@ docker-compose -f lokole/docker/docker-compose.prod.yml up -d
 #
 # set up nginx
 #
-cat > lokole/secrets/nginx.env << EOM
+cat >lokole/secrets/nginx.env <<EOM
 NGINX_WORKERS=auto
 HOSTNAME_WEBAPP=localhost:8080
 HOSTNAME_EMAIL_RECEIVE=localhost:8888


### PR DESCRIPTION
Resolves https://github.com/ascoderu/lokole/issues/293. We've added the [sh formatter](https://github.com/mvdan/sh) to lint our bash scripts. For context of a typical workflow see the attached image.

![AintNoPartyLikeAnShFormatterParty](https://user-images.githubusercontent.com/15795163/82290134-0dc04700-995b-11ea-9a29-fc569e084ff0.png)

CI would fail if any bash scripts don't meet the sh formatter's style guide; which adheres to Google's style guide via the command `shfmt -i 2 -ci `. The offending file is printed out to stdout and the lines prefixed with a - (minus) ought to be replaced with the lines prefixed with a + (plus). See sample image above. This would need to be done for each offending file until CI passes.
