### PR TITLE
Make reply-all consider recipients of email

### DIFF
--- a/opwen_email_client/webapp/views.py
+++ b/opwen_email_client/webapp/views.py
@@ -149,8 +149,9 @@ def email_delete(email_uid: str) -> Response:
 @track_history
 def email_new() -> Response:
     email_store = app.ioc.email_store
+    user = current_user
 
-    form = NewEmailForm.from_request(email_store)
+    form = NewEmailForm.from_request(user, email_store)
     if form is None:
         return abort(404)
 


### PR DESCRIPTION
When replying-all to an email, previously recipients of the replied email weren't being added to the new email. This pull request changes this behavior by adding all people who were on the TO or CC line of the replied email to the CC line of the new email.

Fixes https://github.com/ascoderu/lokole/issues/449