### PR TITLE
Fix isort deprecation warning

### DIFF
--- a/docker/app/run-ci.sh
+++ b/docker/app/run-ci.sh
@@ -6,7 +6,7 @@ scriptdir="$(dirname "$0")"
 cd "${scriptdir}/../.."
 
 flake8 opwen_email_server opwen_email_client
-isort --check-only --recursive opwen_email_server opwen_email_client
+isort --check-only opwen_email_server opwen_email_client
 yapf --recursive --parallel --diff opwen_email_server opwen_email_client tests
 bandit --recursive opwen_email_server opwen_email_client
 mypy opwen_email_server opwen_email_client


### PR DESCRIPTION
This pull request fixes the following deprecation warning which was introduced in 70b542e.

```
/usr/local/lib/python3.7/site-packages/isort/main.py:915: UserWarning: W0501: The following deprecated CLI flags were used and ignored: --recursive!
  "W0501: The following deprecated CLI flags were used and ignored: "
/usr/local/lib/python3.7/site-packages/isort/main.py:919: UserWarning: W0500: Please see the 5.0.0 Upgrade guide: https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/
  "W0500: Please see the 5.0.0 Upgrade guide: "
```