### PR TITLE
Client Register UI

### DIFF
--- a/opwen_email_client/webapp/actions.py
+++ b/opwen_email_client/webapp/actions.py
@@ -3,8 +3,6 @@ from importlib import import_module
 from json import loads
 from logging import Logger
 from pathlib import Path
-from requests.exceptions import HTTPError
-from requests import get
 from subprocess import check_call  # nosec
 from subprocess import check_output  # nosec
 from sys import executable
@@ -14,6 +12,8 @@ from typing import Optional
 
 from cached_property import cached_property
 from flask import render_template
+from requests import get
+from requests.exceptions import HTTPError
 
 from opwen_email_client.domain import sim
 from opwen_email_client.domain.email.store import EmailStore

--- a/opwen_email_client/webapp/actions.py
+++ b/opwen_email_client/webapp/actions.py
@@ -9,7 +9,6 @@ from subprocess import check_call  # nosec
 from subprocess import check_output  # nosec
 from sys import executable
 from time import sleep
-from typing import List
 from typing import Mapping
 from typing import Optional
 from urllib.error import HTTPError
@@ -231,6 +230,7 @@ class StartInternetConnection(object):
             if connection is not None:
                 connection.terminate()
 
+
 class ClientRegister(object):
     def __init__(self, client_name: str, username: str, access_token: str, logger: Logger):
         self._client_name = client_name
@@ -263,7 +263,7 @@ class ClientRegister(object):
         except HTTPError as ex:
             self._log.exception('Unable to register client {client_name}: [{status_code}] {message}'.format(
                 client_name=self._client_name,
-                status_code = ex.code,
+                status_code=ex.code,
                 message=ex.read().decode('utf-8').strip()
             ))
 

--- a/opwen_email_client/webapp/actions.py
+++ b/opwen_email_client/webapp/actions.py
@@ -5,7 +5,6 @@ from logging import Logger
 from pathlib import Path
 from requests.exceptions import HTTPError
 from requests import get
-from requests import post
 from subprocess import check_call  # nosec
 from subprocess import check_output  # nosec
 from sys import executable
@@ -248,8 +247,7 @@ class ClientRegister(object):
 
     def _fetch_settings(self):
         if AppConfig.RESTART_PATHS:
-            restart_paths_list = ['{}={}'.format(key, value) for (key, value) in
-                                    AppConfig.RESTART_PATHS.items()]
+            restart_paths_list = ['{}={}'.format(key, value) for (key, value) in AppConfig.RESTART_PATHS.items()]
             restart_path = ','.join(restart_paths_list)
         else:
             restart_path = ''
@@ -267,17 +265,14 @@ class ClientRegister(object):
         }
 
     def _write_settings_to_file(self, client_settings, client_details):
-        client_settings_list = ['{}={}'.format(key, value) for (key, value) in
-                                client_settings.items()]
-        client_details_list = ['{}={}'.format(key, value) for (key, value) in
-                                client_details.items()]
+        client_settings_list = ['{}={}'.format(key, value) for (key, value) in client_settings.items()]
+        client_details_list = ['{}={}'.format(key, value) for (key, value) in client_details.items()]
 
         with open(self._path, 'w') as fobj:
             fobj.write('\n'.join(client_settings_list))
             fobj.write('\n'.join(client_details_list))
 
     def __call__(self):
-
         while(True):
             get_headers = {'Authorization': 'Bearer {}'.format(self._github_access_token)}
 
@@ -291,8 +286,7 @@ class ClientRegister(object):
                 self._log.exception('Unable to fetch client {client_name}: [{status_code}] {message}'.format(
                     client_name=self._client_name,
                     status_code=get_response.status_code,
-                    message=ex.read().decode('utf-8').strip()
-                ))
+                    message=ex.read().decode('utf-8').strip()))
             else:
                 client_info = loads(get_response.text)
                 break

--- a/opwen_email_client/webapp/actions.py
+++ b/opwen_email_client/webapp/actions.py
@@ -1,9 +1,7 @@
 from contextlib import contextmanager
 from importlib import import_module
-from json import dumps
 from json import loads
 from logging import Logger
-from logging import getLogger
 from pathlib import Path
 from requests.exceptions import HTTPError
 from requests import get
@@ -30,7 +28,9 @@ from opwen_email_client.domain.modem import modem_is_setup
 from opwen_email_client.domain.modem import setup_modem
 from opwen_email_client.domain.sim import dialup
 from opwen_email_client.util.os import backup
+from opwen_email_client.webapp.config import AppConfig
 from opwen_email_client.webapp.config import i8n
+from opwen_email_client.webapp.config import root_domain
 
 
 class SyncEmails(object):
@@ -232,39 +232,51 @@ class StartInternetConnection(object):
 
 
 class ClientRegister(object):
-    def __init__(self, client_name: str, username: str, access_token: str, logger: Logger):
+    def __init__(self, client_name: str, access_token: str, path: str, logger: Logger):
         self._client_name = client_name
-        self._github_username = username
         self._github_access_token = access_token
-        self._log = logger or getLogger(__name__)
+        self._settings_path = path
+        self._log = logger
 
     @property
     def client_domain(self):
         return '{}.{}'.format(self._client_name, 'lokole.ca')
 
     @property
-    def client_url_create(self):
-        return 'https://{}/api/email/register/'.format('mailserver.lokole.ca')
-
-    @property
     def client_url_details(self):
-        return 'https://{}/api/email/register/{}'.format('mailserver.lokole.ca', self.client_domain)
+        return 'https://{}/api/email/register/{}'.format('mailserver.lokole.ca', self.client_domain)\
+
+    def _fetch_settings(self):
+        if AppConfig.RESTART_PATHS:
+            restart_paths_list = ['{}={}'.format(key, value) for (key, value) in
+                                    AppConfig.RESTART_PATHS.items()]
+            restart_path = ','.join(restart_paths_list)
+        else:
+            restart_path = ''
+
+        return {
+            'OPWEN_APP_ROOT': AppConfig.APP_ROOT,
+            'OPWEN_STATE_DIRECTORY': AppConfig.STATE_BASEDIR,
+            'OPWEN_SESSION_KEY': AppConfig.SECRET_KEY,
+            'OPWEN_MAX_UPLOAD_SIZE_MB': AppConfig.MAX_UPLOAD_SIZE_MB,
+            'OPWEN_SIM_TYPE': AppConfig.SIM_TYPE,
+            'OPWEN_EMAIL_SERVER_HOSTNAME': AppConfig.EMAIL_SERVER_HOSTNAME,
+            'OPWEN_CLIENT_NAME': self.client_name.data.strip(),
+            'OPWEN_ROOT_DOMAIN': root_domain,
+            'OPWEN_RESTART_PATH': restart_path,
+        }
+
+    def _write_settings_to_file(self, client_settings, client_details):
+        client_settings_list = ['{}={}'.format(key, value) for (key, value) in
+                                client_settings.items()]
+        client_details_list = ['{}={}'.format(key, value) for (key, value) in
+                                client_details.items()]
+
+        with open(self._path, 'w') as fobj:
+            fobj.write('\n'.join(client_settings_list))
+            fobj.write('\n'.join(client_details_list))
 
     def __call__(self):
-        create_request_payload = dumps({'domain': self.client_domain}).encode('utf-8')
-        create_headers = {'Content-Type': 'application/json',
-                   'Content-Length': str(len(create_request_payload)),
-                   'Authorization': 'Bearer {}'.format(self._github_access_token)}
-
-        response = post(self.client_url_create, data=create_request_payload, headers=create_headers)
-        try:
-            response.raise_for_status()
-        except HTTPError as ex:
-            self._log.exception('Unable to register client {client_name}: [{status_code}] {message}'.format(
-                client_name=self._client_name,
-                status_code=ex.code,
-                message=ex.read().decode('utf-8').strip()
-            ))
 
         while(True):
             get_headers = {'Authorization': 'Bearer {}'.format(self._github_access_token)}
@@ -285,9 +297,12 @@ class ClientRegister(object):
                 client_info = loads(get_response.text)
                 break
 
-        return {
+        opwen_settings = self._fetch_settings()
+        registration_details = {
             'OPWEN_CLIENT_ID': client_info['client_id'],
             'OPWEN_REMOTE_ACCOUNT_NAME': client_info['storage_account'],
             'OPWEN_REMOTE_ACCOUNT_KEY': client_info['storage_key'],
             'OPWEN_REMOTE_RESOURCE_CONTAINER': client_info['resource_container'],
         }
+
+        self._write_settings_to_file(opwen_settings, registration_details)

--- a/opwen_email_client/webapp/config.py
+++ b/opwen_email_client/webapp/config.py
@@ -24,7 +24,7 @@ class ImageDimensions(object):
 # noinspection PyPep8Naming
 class i8n(object):
     SETTINGS_UPDATED = _('Settings updated! If required, the app will restart soon to reflect the changes.')
-    CLIENT_REGISTERED =_('Client has been registered. The app will restart soon to complete the process')
+    CLIENT_REGISTERED = _('Client has been registered. The app will restart soon to complete the process')
     LOGIN_REQUIRED = _('Please log in to access this page.')
     UNAUTHORIZED = _('You do not have permission to view this page.')
     INVALID_PASSWORD = _('Invalid password.')

--- a/opwen_email_client/webapp/config.py
+++ b/opwen_email_client/webapp/config.py
@@ -24,6 +24,7 @@ class ImageDimensions(object):
 # noinspection PyPep8Naming
 class i8n(object):
     SETTINGS_UPDATED = _('Settings updated! If required, the app will restart soon to reflect the changes.')
+    CLIENT_REGISTERED =_('Client has been registered. The app will restart soon to complete the process')
     LOGIN_REQUIRED = _('Please log in to access this page.')
     UNAUTHORIZED = _('You do not have permission to view this page.')
     INVALID_PASSWORD = _('Invalid password.')

--- a/opwen_email_client/webapp/config.py
+++ b/opwen_email_client/webapp/config.py
@@ -45,6 +45,7 @@ class i8n(object):
     SYNC_SCHEDULE_SYNTAX_DESCRIPTION = _('The syntax is: "minute hour day-of-month month day-of-week". '
                                          'Use "*" for any value or "," to separate multiple values '
                                          'or "-" to define a range of values or "/" for step values.')
+    FAILED_REGISTRATION = _('Registration failed. Please try again.')
     UNEXPECTED_ERROR = _('Unexpected error. Please contact your administrator.')
     PAGE_DOES_NOT_EXIST = _('This page does not exist.')
     USER_DOES_NOT_EXIST = _('This user does not exist.')

--- a/opwen_email_client/webapp/forms/register.py
+++ b/opwen_email_client/webapp/forms/register.py
@@ -1,14 +1,87 @@
+from os import getuid
 from pathlib import Path
-from typing import Optional
+from pwd import getpwuid
+from shutil import chown
 
 from flask_wtf import FlaskForm
+from opwen_email_client.webapp.actions import ClientRegister
+from opwen_email_client.webapp.actions import RestartApp
+from opwen_email_client.webapp.config import AppConfig
+from opwen_email_client.webapp.config import root_domain
 from wtforms import StringField
 from wtforms import SubmitField
 
 
 class RegisterForm(FlaskForm):
 
-    client_id = StringField()
+    client_name = StringField()
     github_username = StringField()
     github_token = StringField()
     submit = SubmitField()
+
+    def register(self):
+        registration_details = self._setup_client()
+        opwen_settings = self._fetch_settings()
+        path = self._setup_path()
+        self._write_settings_to_file(path, opwen_settings, registration_details)
+        self._restart()
+
+    def _setup_client(self):
+        name = self.client_name.data.strip()
+        username = self.github_username.data.strip()
+        token = self.github_token.data.strip()
+        register = ClientRegister(name, username, token, None)
+        client_details = register()
+        return client_details
+
+    def _fetch_settings(self):
+        if AppConfig.RESTART_PATHS:
+            restart_paths_list = []
+            for key, value in AppConfig.RESTART_PATHS.items():
+                restart_paths_list.append('{}={}'.format(key, value))
+            restart_path = ','.join(restart_paths_list)
+        else:
+            restart_path = ''
+
+        return {
+            'OPWEN_APP_ROOT': AppConfig.APP_ROOT,
+            'OPWEN_STATE_DIRECTORY': AppConfig.STATE_BASEDIR,
+            'OPWEN_SESSION_KEY': AppConfig.SECRET_KEY,
+            'OPWEN_MAX_UPLOAD_SIZE_MB': AppConfig.MAX_UPLOAD_SIZE_MB,
+            'OPWEN_SIM_TYPE': AppConfig.SIM_TYPE,
+            'OPWEN_EMAIL_SERVER_HOSTNAME': AppConfig.EMAIL_SERVER_HOSTNAME,
+            'OPWEN_CLIENT_NAME': self.client_name.data.strip(),
+            'OPWEN_ROOT_DOMAIN': root_domain,
+            'OPWEN_RESTART_PATH': restart_path,
+        }
+
+    def _setup_path(self):
+        user = getpwuid(getuid()).pw_name
+        home = Path('/') / 'home' / user
+        path = Path('lokole/state/settings.env')
+        path = path.absolute()
+        parent = path.parent
+        parent.mkdir(parents=True, exist_ok=True)
+        is_in_home = parent.parts[:3] == home_prefix.parts
+        if is_in_home:
+            home_parts = parent.parts[3:]
+            for part in home_parts:
+                home_prefix /= part
+                chown(str(home_prefix), user, user)
+        return str(path)
+
+    def _write_settings_to_file(self, path, client_settings, client_details):
+        client_settings_list = []
+        for key, value in client_settings.items():
+            client_settings_list.append('{}={}'.format(key, value))
+        client_details_list = []
+        for key, value in client_details.items():
+            client_details_list.append('{}={}'.format(key, value))
+
+        with open(path, 'w') as fobj:
+            fobj.write('\n'.join(client_settings_list))
+            fobj.write('\n'.join(client_details_list))
+
+    def _restart(self):
+        restart_app = RestartApp(restart_paths=AppConfig.RESTART_PATHS)
+        restart_app()

--- a/opwen_email_client/webapp/forms/register.py
+++ b/opwen_email_client/webapp/forms/register.py
@@ -62,7 +62,7 @@ class RegisterForm(FlaskForm):
         path = path.absolute()
         parent = path.parent
         parent.mkdir(parents=True, exist_ok=True)
-        is_in_home = parent.parts[:3] == home_prefix.parts
+        is_in_home = parent.parts[:3] == home.parts
         if is_in_home:
             home_parts = parent.parts[3:]
             for part in home_parts:

--- a/opwen_email_client/webapp/forms/register.py
+++ b/opwen_email_client/webapp/forms/register.py
@@ -1,17 +1,19 @@
 from os import getenv
 from os import getuid
+from json import dumps
 from pathlib import Path
 from pwd import getpwuid
 from shutil import chown
 
 from flask_wtf import FlaskForm
+from requests import post
 from wtforms import StringField
 from wtforms import SubmitField
 
 from opwen_email_client.webapp.actions import ClientRegister
-from opwen_email_client.webapp.actions import RestartApp
 from opwen_email_client.webapp.config import AppConfig
 from opwen_email_client.webapp.config import root_domain
+from opwen_email_client.webapp.tasks import register
 
 
 class RegisterForm(FlaskForm):
@@ -22,39 +24,23 @@ class RegisterForm(FlaskForm):
     submit = SubmitField()
 
     def register(self):
-        registration_details = self._setup_client()
-        opwen_settings = self._fetch_settings()
         path = self._setup_path()
-        self._write_settings_to_file(path, opwen_settings, registration_details)
-        self._restart()
+        self._setup_client(path)
 
-    def _setup_client(self):
+    def _setup_client(self, path):
         name = self.client_name.data.strip()
         username = self.github_username.data.strip()
         token = self.github_token.data.strip()
-        register = ClientRegister(name, username, token, None)
-        client_details = register()
-        return client_details
 
-    def _fetch_settings(self):
-        if AppConfig.RESTART_PATHS:
-            restart_paths_list = ['{}={}'.format(key, value) for (key, value) in
-                                    AppConfig.RESTART_PATHS.items()]
-            restart_path = ','.join(restart_paths_list)
-        else:
-            restart_path = ''
+        client_domain = '{}.{}'.format(name, 'lokole.ca')
+        client_create_url = 'https://{}/api/email/register/'.format('mailserver.lokole.ca')
+        create_request_payload = dumps({'domain': client_domain}).encode('utf-8')
+        create_headers = {'Content-Type': 'application/json',
+                          'Content-Length': str(len(create_request_payload)),
+                          'Authorization': 'Bearer {}'.format(token)}
 
-        return {
-            'OPWEN_APP_ROOT': AppConfig.APP_ROOT,
-            'OPWEN_STATE_DIRECTORY': AppConfig.STATE_BASEDIR,
-            'OPWEN_SESSION_KEY': AppConfig.SECRET_KEY,
-            'OPWEN_MAX_UPLOAD_SIZE_MB': AppConfig.MAX_UPLOAD_SIZE_MB,
-            'OPWEN_SIM_TYPE': AppConfig.SIM_TYPE,
-            'OPWEN_EMAIL_SERVER_HOSTNAME': AppConfig.EMAIL_SERVER_HOSTNAME,
-            'OPWEN_CLIENT_NAME': self.client_name.data.strip(),
-            'OPWEN_ROOT_DOMAIN': root_domain,
-            'OPWEN_RESTART_PATH': restart_path,
-        }
+        response = post(client_create_url, data=create_request_payload, headers=create_headers)
+        response.raise_for_status()
 
     def _setup_path(self):
         home = Path.home()
@@ -69,17 +55,3 @@ class RegisterForm(FlaskForm):
                 home /= part
                 chown(str(home), user, user)
         return str(path)
-
-    def _write_settings_to_file(self, path, client_settings, client_details):
-        client_settings_list = ['{}={}'.format(key, value) for (key, value) in
-                                client_settings.items()]
-        client_details_list = ['{}={}'.format(key, value) for (key, value) in
-                                client_details.items()]
-
-        with open(path, 'w') as fobj:
-            fobj.write('\n'.join(client_settings_list))
-            fobj.write('\n'.join(client_details_list))
-
-    def _restart(self):
-        restart_app = RestartApp(restart_paths=AppConfig.RESTART_PATHS)
-        restart_app()

--- a/opwen_email_client/webapp/forms/register.py
+++ b/opwen_email_client/webapp/forms/register.py
@@ -1,8 +1,6 @@
 from os import getenv
-from os import getuid
 from json import dumps
 from pathlib import Path
-from pwd import getpwuid
 from shutil import chown
 
 from flask_wtf import FlaskForm
@@ -10,9 +8,6 @@ from requests import post
 from wtforms import StringField
 from wtforms import SubmitField
 
-from opwen_email_client.webapp.actions import ClientRegister
-from opwen_email_client.webapp.config import AppConfig
-from opwen_email_client.webapp.config import root_domain
 from opwen_email_client.webapp.tasks import register
 
 
@@ -23,13 +18,12 @@ class RegisterForm(FlaskForm):
     github_token = StringField()
     submit = SubmitField()
 
-    def register(self):
+    def register_client(self):
         path = self._setup_path()
         self._setup_client(path)
 
     def _setup_client(self, path):
         name = self.client_name.data.strip()
-        username = self.github_username.data.strip()
         token = self.github_token.data.strip()
 
         client_domain = '{}.{}'.format(name, 'lokole.ca')
@@ -41,6 +35,7 @@ class RegisterForm(FlaskForm):
 
         response = post(client_create_url, data=create_request_payload, headers=create_headers)
         response.raise_for_status()
+        register.delay(name, token, path)
 
     def _setup_path(self):
         home = Path.home()

--- a/opwen_email_client/webapp/forms/register.py
+++ b/opwen_email_client/webapp/forms/register.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from typing import Optional
+
+from flask_wtf import FlaskForm
+from wtforms import StringField
+from wtforms import SubmitField
+
+
+class RegisterForm(FlaskForm):
+
+    client_id = StringField()
+    github_username = StringField()
+    github_token = StringField()
+    submit = SubmitField()

--- a/opwen_email_client/webapp/forms/register.py
+++ b/opwen_email_client/webapp/forms/register.py
@@ -66,8 +66,8 @@ class RegisterForm(FlaskForm):
         if is_in_home:
             home_parts = parent.parts[3:]
             for part in home_parts:
-                home_prefix /= part
-                chown(str(home_prefix), user, user)
+                home /= part
+                chown(str(home), user, user)
         return str(path)
 
     def _write_settings_to_file(self, path, client_settings, client_details):

--- a/opwen_email_client/webapp/forms/register.py
+++ b/opwen_email_client/webapp/forms/register.py
@@ -12,6 +12,7 @@ from opwen_email_client.webapp.config import AppConfig
 from opwen_email_client.webapp.config import i8n
 from opwen_email_client.webapp.tasks import register
 
+
 class RegisterForm(FlaskForm):
 
     client_name = StringField()
@@ -31,7 +32,9 @@ class RegisterForm(FlaskForm):
         client_domain = '{}.{}'.format(name, 'lokole.ca')
         client_create_url = 'https://{}/api/email/register/'.format(endpoint)
 
-        response = post(client_create_url, json={'domain': client_domain}, headers={'Authorization': 'Bearer {}'.format(token)})
+        response = post(client_create_url,
+                        json={'domain': client_domain},
+                        headers={'Authorization': 'Bearer {}'.format(token)})
         if response.status != 200:
             raise ValidationError(i8n.FAILED_REGISTRATION)
         register.delay(name, token, path)

--- a/opwen_email_client/webapp/tasks.py
+++ b/opwen_email_client/webapp/tasks.py
@@ -3,6 +3,7 @@ from celery.schedules import crontab
 from celery.utils.log import get_task_logger
 
 from opwen_email_client.util.network import check_connection
+from opwen_email_client.webapp.actions import ClientRegister
 from opwen_email_client.webapp.actions import RestartApp
 from opwen_email_client.webapp.actions import StartInternetConnection
 from opwen_email_client.webapp.actions import SyncEmails
@@ -74,3 +75,18 @@ def update(*args, **kwargs):
             update_code()
 
         restart_app()
+
+
+@app.task(ignore_result=True)
+def register(name, token, path, **kwargs):
+    client_register = ClientRegister(
+        client_name=name,
+        access_token=token,
+        path=path,
+        logger=log,
+    )
+
+    restart_app = RestartApp(restart_paths=AppConfig.RESTART_PATHS)
+
+    client_register()
+    restart_app()

--- a/opwen_email_client/webapp/templates/client_register.html
+++ b/opwen_email_client/webapp/templates/client_register.html
@@ -1,0 +1,31 @@
+{% extends "_base.html" %}
+
+{% block title %}{{ _('Register | Lokole') }}{% endblock %}
+
+{% from 'macros/form.html' import render_field %}
+{% from 'macros/form.html' import render_button %}
+
+{% block libs %}{{ super() }}
+<link rel="stylesheet" type="text/css" href="{{ 'css/settings.css' | asset_url }}">
+{% endblock %}
+
+{% block content %}{{ super() }}
+<main>
+<form action="{{ url_for('settings') }}" method="post" name="{{ form.name }}" enctype="multipart/form-data">
+  {{ form.hidden_tag() }}
+
+  <fieldset>
+
+    {{ render_field(form.client_id) }}
+
+    {{ render_field(form.github_username) }}
+
+    {{ render_field(form.github_token) }}
+
+  </fieldset>
+
+  {{ render_button(form.submit, _('Register new client')) }}
+</form>
+</main>
+
+{% endblock %}

--- a/opwen_email_client/webapp/templates/register.html
+++ b/opwen_email_client/webapp/templates/register.html
@@ -11,12 +11,12 @@
 
 {% block content %}{{ super() }}
 <main>
-<form action="{{ url_for('settings') }}" method="post" name="{{ form.name }}" enctype="multipart/form-data">
+<form action="{{ url_for('register') }}" method="post" name="{{ form.name }}" enctype="multipart/form-data">
   {{ form.hidden_tag() }}
 
   <fieldset>
 
-    {{ render_field(form.client_id) }}
+    {{ render_field(form.client_name) }}
 
     {{ render_field(form.github_username) }}
 

--- a/opwen_email_client/webapp/views.py
+++ b/opwen_email_client/webapp/views.py
@@ -27,11 +27,17 @@ from opwen_email_client.webapp.actions import SendWelcomeEmail
 from opwen_email_client.webapp.config import AppConfig
 from opwen_email_client.webapp.config import i8n
 from opwen_email_client.webapp.forms.email import NewEmailForm
+from opwen_email_client.webapp.forms.register import RegisterForm
 from opwen_email_client.webapp.forms.settings import SettingsForm
 from opwen_email_client.webapp.security import login_required
 from opwen_email_client.webapp.session import Session
 from opwen_email_client.webapp.session import track_history
 
+
+@app.before_first_request
+def check_client_registration() -> Response:
+    if AppConfig.CLIENT_ID is None and AppConfig.SIM_TYPE != 'LocalOnly':
+        return redirect(url_for('home'))
 
 @app.route(AppConfig.APP_ROOT + '/favicon.ico')
 def favicon() -> Response:
@@ -276,6 +282,19 @@ def settings() -> Response:
         return redirect(url_for('settings'))
 
     return _view('settings.html', form=SettingsForm.from_config(), num_pending=email_store.num_pending())
+
+
+@app.route(AppConfig.APP_ROOT + '/admin/register', methods=['GET', 'POST'])
+@track_history
+def register() -> Response:
+    if not current_user.is_admin:
+        abort(403)
+
+    form = RegisterForm()
+    if form.validate_on_submit():
+        return redirect(url_for('home'))
+
+    return _view('client_register.html', form=form)
 
 
 @app.route(AppConfig.APP_ROOT + '/admin/suspend/<userid>')

--- a/opwen_email_client/webapp/views.py
+++ b/opwen_email_client/webapp/views.py
@@ -288,7 +288,7 @@ def register() -> Response:
     form = RegisterForm()
     if form.validate_on_submit():
         form.register()
-        flash(i8n.CLENT_REGISTERED, category='success')
+        flash(i8n.CLIENT_REGISTERED, category='success')
         return redirect(url_for('home'))
 
     return _view('register.html', form=form)

--- a/opwen_email_client/webapp/views.py
+++ b/opwen_email_client/webapp/views.py
@@ -34,11 +34,6 @@ from opwen_email_client.webapp.session import track_history
 from passlib.pwd import genword
 
 
-@app.before_first_request
-def check_client_registration() -> Response:
-    if AppConfig.CLIENT_ID is None and AppConfig.SIM_TYPE != 'LocalOnly':
-        return redirect(url_for('register'))
-
 @app.route(AppConfig.APP_ROOT + '/favicon.ico')
 def favicon() -> Response:
     return send_from_directory(
@@ -469,6 +464,12 @@ def _emails_view(emails: Iterable[dict], page: int, template: str = 'email.html'
                  has_prevpage=page > 1,
                  has_nextpage=len(emails) == AppConfig.EMAILS_PER_PAGE,
                  **kwargs)
+
+
+@app.before_first_request
+def check_client_registration() -> Response:
+    if not AppConfig.CLIENT_ID and AppConfig.SIM_TYPE != 'LocalOnly':
+        return redirect(url_for('register'))
 
 
 def _view(template: str, **kwargs) -> Response:

--- a/opwen_email_client/webapp/views.py
+++ b/opwen_email_client/webapp/views.py
@@ -5,6 +5,7 @@ from os import path
 from typing import Iterable
 from typing import Optional
 
+from babel import Locale
 from flask import Response
 from flask import abort
 from flask import flash
@@ -15,11 +16,11 @@ from flask import request
 from flask import send_file
 from flask import send_from_directory
 from flask import url_for
-
-from babel import Locale
 from flask_cors import cross_origin
 from flask_login import current_user
 from flask_security.utils import hash_password
+from passlib.pwd import genword
+
 from opwen_email_client.webapp import app
 from opwen_email_client.webapp import tasks
 from opwen_email_client.webapp.actions import SendWelcomeEmail
@@ -31,7 +32,7 @@ from opwen_email_client.webapp.forms.settings import SettingsForm
 from opwen_email_client.webapp.security import login_required
 from opwen_email_client.webapp.session import Session
 from opwen_email_client.webapp.session import track_history
-from passlib.pwd import genword
+
 
 
 @app.route(AppConfig.APP_ROOT + '/favicon.ico')

--- a/opwen_email_client/webapp/views.py
+++ b/opwen_email_client/webapp/views.py
@@ -5,7 +5,6 @@ from os import path
 from typing import Iterable
 from typing import Optional
 
-from babel import Locale
 from flask import Response
 from flask import abort
 from flask import flash
@@ -16,11 +15,11 @@ from flask import request
 from flask import send_file
 from flask import send_from_directory
 from flask import url_for
+
+from babel import Locale
 from flask_cors import cross_origin
 from flask_login import current_user
 from flask_security.utils import hash_password
-from passlib.pwd import genword
-
 from opwen_email_client.webapp import app
 from opwen_email_client.webapp import tasks
 from opwen_email_client.webapp.actions import SendWelcomeEmail
@@ -32,12 +31,13 @@ from opwen_email_client.webapp.forms.settings import SettingsForm
 from opwen_email_client.webapp.security import login_required
 from opwen_email_client.webapp.session import Session
 from opwen_email_client.webapp.session import track_history
+from passlib.pwd import genword
 
 
 @app.before_first_request
 def check_client_registration() -> Response:
     if AppConfig.CLIENT_ID is None and AppConfig.SIM_TYPE != 'LocalOnly':
-        return redirect(url_for('home'))
+        return redirect(url_for('register'))
 
 @app.route(AppConfig.APP_ROOT + '/favicon.ico')
 def favicon() -> Response:
@@ -292,9 +292,11 @@ def register() -> Response:
 
     form = RegisterForm()
     if form.validate_on_submit():
+        form.register()
+        flash(i8n.CLENT_REGISTERED, category='success')
         return redirect(url_for('home'))
 
-    return _view('client_register.html', form=form)
+    return _view('register.html', form=form)
 
 
 @app.route(AppConfig.APP_ROOT + '/admin/suspend/<userid>')

--- a/opwen_email_client/webapp/views.py
+++ b/opwen_email_client/webapp/views.py
@@ -34,7 +34,6 @@ from opwen_email_client.webapp.session import Session
 from opwen_email_client.webapp.session import track_history
 
 
-
 @app.route(AppConfig.APP_ROOT + '/favicon.ico')
 def favicon() -> Response:
     return send_from_directory(

--- a/opwen_email_client/webapp/views.py
+++ b/opwen_email_client/webapp/views.py
@@ -287,7 +287,7 @@ def register() -> Response:
 
     form = RegisterForm()
     if form.validate_on_submit():
-        form.register()
+        form.register_client()
         flash(i8n.CLIENT_REGISTERED, category='success')
         return redirect(url_for('home'))
 


### PR DESCRIPTION
#454 

The client registration process is normally done in the install script. The client registration step has been ported to the webapp and makes it possible for IIAB users to register a client and gain online functionality. A new route has been added (/admin/register) where one provides the client name, a GitHub username and access token to register a new client. 

In order to complete this fully, environment variables must be added to the ansible templates on the IIAB side [here](https://github.com/iiab/iiab/blob/master/roles/lokole/templates/webapp_secrets.sh.j2)