### PR TITLE
Temporary fix for Github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Docs:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-pull-request-reviews-before-merging
+
+/makefile           @ascoderu/lokole-dev
+/.github.env.gpg    @ascoderu/lokole-dev
+/docker-compose.yml @ascoderu/lokole-dev
+/docker/            @ascoderu/lokole-dev
+/.github            @ascoderu/lokole-dev


### PR DESCRIPTION
This PR runs the PRs with `pull_request_target` trigger thus reading environment variables from the target rather that the fork which lead to failure of `test-live` job.
