### PR TITLE
feat: Add integration test workflow + Python 3.12 setuptools fix

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -1,0 +1,46 @@
+name: Trigger Integration Tests
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  push:
+    branches:
+      - master
+
+jobs:
+  trigger-on-label:
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test-iiab-integration')
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Trigger integration tests
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.INTEGRATION_TEST_PAT }}
+          repository: ascoderu/iiab-lokole-tests
+          event-type: test-integration-lokole
+          client-payload: |
+            {
+              "pr_number": ${{ github.event.pull_request.number }},
+              "ref": "${{ github.event.pull_request.head.ref }}",
+              "sha": "${{ github.event.pull_request.head.sha }}",
+              "repo": "${{ github.repository }}"
+            }
+  
+  trigger-on-merge:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Trigger post-merge tests
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.INTEGRATION_TEST_PAT }}
+          repository: ascoderu/iiab-lokole-tests
+          event-type: lokole-merged
+          client-payload: |
+            {
+              "branch": "${{ github.ref_name }}",
+              "sha": "${{ github.sha }}",
+              "repo": "${{ github.repository }}"
+            }

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -16,7 +16,7 @@ jobs:
   trigger-on-label:
     if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'test-iiab-integration')
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Trigger integration tests
         uses: peter-evans/repository-dispatch@v2
@@ -31,11 +31,11 @@ jobs:
               "sha": "${{ github.event.pull_request.head.sha }}",
               "repo": "${{ github.repository }}"
             }
-  
+
   trigger-on-merge:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Trigger post-merge tests
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -1,15 +1,20 @@
 name: Trigger Integration Tests
 
 on:
-  pull_request:
-    types: [labeled, synchronize]
+  # Use pull_request_target for fork PRs to access secrets when labeled by maintainers
+  # This is safe because:
+  # 1. We don't checkout or execute any code from the PR
+  # 2. We only read PR metadata and dispatch to another repo
+  # 3. The label must be manually added by someone with write access
+  pull_request_target:
+    types: [labeled]
   push:
     branches:
       - master
 
 jobs:
   trigger-on-label:
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test-iiab-integration')
+    if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'test-iiab-integration')
     runs-on: ubuntu-latest
     
     steps:

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -1,4 +1,4 @@
-setuptools>=65.5.0  # Required for pkg_resources in Python 3.12+ (no longer included by default)
+setuptools>=65.5.0,<73.0.0  # Required for pkg_resources in Python 3.12+ (no longer included by default). Upper bound because setuptools 73+ removed pkg_resources
 Babel==2.14.0  # 2.14.0+ required for Python 3.13 (removed cgi module dependency)
 Flask-BabelEx==0.9.4
 pytz  # Required by Flask-BabelEx (no longer a transitive dep of Babel 2.14+)

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -1,3 +1,4 @@
+setuptools>=65.5.0  # Required for pkg_resources in Python 3.12+ (no longer included by default)
 Babel==2.14.0  # 2.14.0+ required for Python 3.13 (removed cgi module dependency)
 Flask-BabelEx==0.9.4
 pytz  # Required by Flask-BabelEx (no longer a transitive dep of Babel 2.14+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==2.2.1
 Flask-Cors==3.0.10
 Pillow==10.4.0  # 10.1.0+ required for Python 3.13 support
+setuptools>=65.5.0,<73.0.0  # Required for pkg_resources (gunicorn dependency). setuptools 73+ removed pkg_resources
 apache-libcloud==3.6.0
 applicationinsights==0.11.10
 beautifulsoup4==4.11.1


### PR DESCRIPTION
## Changes

### 1. Integration Test Trigger Workflow
- Adds GitHub Actions workflow to trigger IIAB integration tests
- Uses label `test-integration` on PRs to trigger tests in `iiab-lokole-tests` repo
- Sends PR details (number, ref, sha, repo) to test infrastructure

### 2. Python 3.12+ Compatibility Fix
- Adds `setuptools>=65.5.0` to `requirements-webapp.txt`
- **Problem**: Python 3.12+ no longer includes setuptools by default
- **Issue**: `flask-security==3.0.0` imports `pkg_resources` which requires setuptools
- **Error**: `ModuleNotFoundError: No module named 'pkg_resources'`
- **Solution**: Explicitly add setuptools as a runtime dependency

## Testing
- Tested with IIAB PR #4259 on Ubuntu 24.04 with Python 3.12
- Integration test workflow successfully dispatches events
- Setuptools fix resolves pkg_resources import error

## Related
- IIAB PR: iiab/iiab#4259 (Python 3.12 compatibility)
- Test Infrastructure: ascoderu/iiab-lokole-tests