### PR TITLE
fix: wrap sync task in Flask application context

### DIFF
--- a/opwen_email_client/webapp/tasks.py
+++ b/opwen_email_client/webapp/tasks.py
@@ -31,26 +31,27 @@ def setup_periodic_tasks(sender, **kwargs):
 def sync(*args, **kwargs):
     from opwen_email_client.webapp import app as webapp
 
-    sync_emails = SyncEmails(
-        log=log,
-        email_sync=webapp.ioc.email_sync,
-        email_store=webapp.ioc.email_store,
-        user_store=webapp.ioc.user_store,
-    )
-
-    if check_connection(AppConfig.EMAIL_SERVER_HOSTNAME, 80):
-        sync_emails()
-    else:
-        start_internet_connection = StartInternetConnection(
-            state_dir=AppConfig.STATE_BASEDIR,
-            modem_config_dir=AppConfig.MODEM_CONFIG_DIR,
-            sim_config_dir=AppConfig.SIM_CONFIG_DIR,
-            sim_type=AppConfig.SIM_TYPE,
+    with webapp.app_context():
+        sync_emails = SyncEmails(
+            log=log,
+            email_sync=webapp.ioc.email_sync,
+            email_store=webapp.ioc.email_store,
+            user_store=webapp.ioc.user_store,
         )
 
-        if AppConfig.SIM_TYPE != 'LocalOnly':
-            with start_internet_connection():
-                sync_emails()
+        if check_connection(AppConfig.EMAIL_SERVER_HOSTNAME, 80):
+            sync_emails()
+        else:
+            start_internet_connection = StartInternetConnection(
+                state_dir=AppConfig.STATE_BASEDIR,
+                modem_config_dir=AppConfig.MODEM_CONFIG_DIR,
+                sim_config_dir=AppConfig.SIM_CONFIG_DIR,
+                sim_type=AppConfig.SIM_TYPE,
+            )
+
+            if AppConfig.SIM_TYPE != 'LocalOnly':
+                with start_internet_connection():
+                    sync_emails()
 
 
 # noinspection PyUnusedLocal


### PR DESCRIPTION
## Problem

The celery sync task was failing silently with a RuntimeError when trying to commit database changes:

```
RuntimeError: No application found. Either work inside a view function or push an application context.
```

This happens because the async task executes **outside of Flask's application context**. When `_mark_as_synced()` tries to commit via `db.session.commit()`, Flask-SQLAlchemy needs an active application context to function.

## Root Cause

Celery worker processes run independently from the Flask application. Database operations that depend on Flask-SQLAlchemy's request/app context must be explicitly wrapped.

## Solution

Wrap the sync task execution in a Flask application context using `with webapp.app_context():`. This ensures SQLAlchemy session handling works correctly during database operations.

## Changes

- Updated `sync()` task in `tasks.py` to wrap all operations in `webapp.app_context()`
- Maintains all existing logic and error handling
- No changes to dependencies or API

## Testing

- ✅ Upload completes successfully (HTTP 200 to server)
- ✅ Database commit succeeds without RuntimeError  
- ✅ Emails marked as synced in local database

## Related

Complements systemctl service restart fix in PR #614