### PR TITLE
Fix: Update SendGrid webhook when client_id changes

### DIFF
--- a/opwen_email_server/integration/cli.py
+++ b/opwen_email_server/integration/cli.py
@@ -55,9 +55,9 @@ def delete_queues(suffix):
         return
 
     # https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/servicebus/azure-servicebus/migration_guide.md#working-with-administration-client
-    connection_string = f"Endpoint=sb://{config.QUEUE_BROKER_HOST}.servicebus.windows.net/;" \
-                        f"SharedAccessKeyName={config.QUEUE_BROKER_USERNAME};" \
-                        f"SharedAccessKey={config.QUEUE_BROKER_PASSWORD}"
+    connection_string = (f"Endpoint=sb://{config.QUEUE_BROKER_HOST}.servicebus.windows.net/;"
+                         f"SharedAccessKeyName={config.QUEUE_BROKER_USERNAME};"
+                         f"SharedAccessKey={config.QUEUE_BROKER_PASSWORD}")
 
     with ServiceBusAdministrationClient.from_connection_string(connection_string) as servicebus_mgmt_client:
         for queue in servicebus_mgmt_client.list_queues():

--- a/opwen_email_server/services/sendgrid.py
+++ b/opwen_email_server/services/sendgrid.py
@@ -7,6 +7,7 @@ from cached_property import cached_property
 from python_http_client import BadRequestsError
 from requests import delete as http_delete
 from requests import get as http_get
+from requests import patch as http_patch
 from requests import post as http_post
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Attachment
@@ -191,7 +192,29 @@ class SetupSendgridMailbox(_SendgridManagement):
             )
 
             if get_response.ok:
-                self.log_debug('Mailbox %s already exists', domain)
+                existing_config = get_response.json()
+                expected_url = INBOX_URL.format(client_id)
+                current_url = existing_config.get('url', '')
+
+                if current_url != expected_url:
+                    self.log_info('Updating stale webhook for %s: %s -> %s', domain, current_url, expected_url)
+                    patch_response = http_patch(
+                        url=MAILBOX_DETAIL_URL.format(domain),
+                        json={
+                            'hostname': domain,
+                            'url': expected_url,
+                            'spam_check': existing_config.get('spam_check', True),
+                            'send_raw': existing_config.get('send_raw', True),
+                        },
+                        headers={
+                            'Authorization': f'Bearer {self._key}',
+                        },
+                    )
+                    if not patch_response.ok:
+                        patch_response.raise_for_status()
+                    self.log_info('Updated mailbox for %s', domain)
+                else:
+                    self.log_debug('Mailbox %s already exists with correct URL', domain)
                 break
 
             create_response = http_post(

--- a/tests/opwen_email_server/services/test_sendgrid.py
+++ b/tests/opwen_email_server/services/test_sendgrid.py
@@ -181,6 +181,10 @@ class SetupSendgridMailboxTests(TestCase):
     def test_skips_request_when_domain_already_exists(self):
         mock_responses.add(mock_responses.GET,
                            'https://api.sendgrid.com/v3/user/webhooks/parse/settings/my-domain',
+                           json={
+                               'url': 'https://mailserver.lokole.ca/api/email/sendgrid/my-client-id', 'spam_check':
+                               True, 'send_raw': True
+                           },
                            status=200)
 
         action = SetupSendgridMailbox('my-key', max_retries=1, retry_interval_seconds=1)
@@ -188,6 +192,29 @@ class SetupSendgridMailboxTests(TestCase):
         action('my-client-id', 'my-domain')
 
         self.assertEqual(len(mock_responses.calls), 1)
+
+    @mock_responses.activate
+    def test_updates_webhook_when_url_mismatches(self):
+        mock_responses.add(mock_responses.GET,
+                           'https://api.sendgrid.com/v3/user/webhooks/parse/settings/my-domain',
+                           json={
+                               'url': 'https://mailserver.lokole.ca/api/email/sendgrid/old-client-id', 'spam_check':
+                               True, 'send_raw': True
+                           },
+                           status=200)
+        mock_responses.add(mock_responses.PATCH,
+                           'https://api.sendgrid.com/v3/user/webhooks/parse/settings/my-domain',
+                           status=200)
+
+        action = SetupSendgridMailbox('my-key', max_retries=1, retry_interval_seconds=1)
+
+        action('new-client-id', 'my-domain')
+
+        self.assertEqual(len(mock_responses.calls), 2)
+        self.assertEqual(mock_responses.calls[0].request.method, 'GET')
+        self.assertEqual(mock_responses.calls[1].request.method, 'PATCH')
+        self.assertIn(b'"url": "https://mailserver.lokole.ca/api/email/sendgrid/new-client-id"',
+                      mock_responses.calls[1].request.body)
 
     @mock_responses.activate
     def test_retries_request_when_creation_failed(self):


### PR DESCRIPTION
## Problem

When a domain is re-registered or configuration changes generate a new `client_id`, inbound emails are rejected with `unregistered_client` errors. This happens because the SendGrid webhook URL still points to the old client ID, while the server expects the new one.

### Root Cause

`SetupSendgridMailbox._run()` would exit early when it found an existing SendGrid mailbox, **without checking if the webhook URL matched the current client_id**. This caused a silent mismatch between:
- What SendGrid knows (old webhook URL with stale client_id)
- What the server expects (new client_id)

### Impact

Production domains lose all inbound email after re-registration until manual SendGrid reconfiguration.

## Solution

Modified `SetupSendgridMailbox._run()` to:
1. **GET** existing SendGrid mailbox configuration
2. **Compare** current webhook URL with expected URL (containing current client_id)
3. **PATCH** the webhook if URLs mismatch, preserving spam_check and send_raw settings
4. **Skip** update only when URL is already correct

## Changes

- Added `http_patch` import to `sendgrid.py`
- Updated `SetupSendgridMailbox._run()` with URL comparison and PATCH logic
- Updated `test_skips_request_when_domain_already_exists` to include JSON response in mock
- Added `test_updates_webhook_when_url_mismatches` to verify PATCH behavior

## Testing

✅ All SendGrid service tests pass  
✅ Code formatted with yapf (column_limit=120)  
✅ Validated with production domain reproduction (lokole-repro-20260601.lokole.ca)

### Before Fix
```python
if get_response.ok:
    self.log_debug('Mailbox %s already exists', domain)
    break  # ❌ Exits without checking URL
```

### After Fix
```python
if get_response.ok:
    existing_config = get_response.json()
    expected_url = INBOX_URL.format(client_id)
    current_url = existing_config.get('url', '')
    
    if current_url != expected_url:
        # ✅ Updates webhook with correct client_id
        http_patch(...)
```

## Deployment Notes

After merge and PyPI release, this fix will automatically apply when `SetupSendgridMailbox` runs (typically during client registration or periodic sync). Affected domains will see log messages: `"Updating stale webhook for {domain}"`.