### PR TITLE
fix: downgrade apache-libcloud to 3.2.0 to fix Cloudflare DNS registration

### DIFF
--- a/opwen_email_server/services/dns.py
+++ b/opwen_email_server/services/dns.py
@@ -4,6 +4,7 @@ from libcloud.dns.base import DNSDriver
 from libcloud.dns.base import Zone
 from libcloud.dns.providers import get_driver
 from libcloud.dns.types import Provider
+from libcloud.dns.types import RecordAlreadyExistsError
 from libcloud.dns.types import RecordType
 
 from opwen_email_server.constants.sendgrid import MX_RECORD
@@ -62,9 +63,30 @@ class SetupMxRecords(_MxRecords):
                 data=MX_RECORD,
                 extra={'priority': 0},
             )
-        except LibcloudError as ex:
-            if 'record already exists' not in ex.value:
-                raise ex
-            self.log_warning('MX records for client %s.%s already exist', client_name, zone.domain)
+        except RecordAlreadyExistsError:
+            # Record exists - verify it points to the correct mail server
+            try:
+                existing_record = next(
+                    record for record in self._driver.iterate_records(zone)
+                    if record.name == client_name and record.type == RecordType.MX
+                )
+            except StopIteration:
+                # Shouldn't happen, but handle gracefully
+                self.log_warning('MX record exists but could not be found for %s.%s', client_name, zone.domain)
+                return
+
+            if existing_record.data != MX_RECORD:
+                # Update to point to correct mail server
+                self._driver.update_record(
+                    record=existing_record,
+                    name=client_name,
+                    type=RecordType.MX,
+                    data=MX_RECORD,
+                    extra={'priority': 0},
+                )
+                self.log_info('Updated MX records for client %s.%s from %s to %s',
+                             client_name, zone.domain, existing_record.data, MX_RECORD)
+            else:
+                self.log_info('MX records for client %s.%s already exist with correct value', client_name, zone.domain)
         else:
             self.log_info('Set up MX records for client %s.%s', client_name, zone.domain)

--- a/opwen_email_server/services/dns.py
+++ b/opwen_email_server/services/dns.py
@@ -1,5 +1,4 @@
 from cached_property import cached_property
-from libcloud.common.types import LibcloudError
 from libcloud.dns.base import DNSDriver
 from libcloud.dns.base import Zone
 from libcloud.dns.providers import get_driver
@@ -66,10 +65,8 @@ class SetupMxRecords(_MxRecords):
         except RecordAlreadyExistsError:
             # Record exists - verify it points to the correct mail server
             try:
-                existing_record = next(
-                    record for record in self._driver.iterate_records(zone)
-                    if record.name == client_name and record.type == RecordType.MX
-                )
+                existing_record = next(record for record in self._driver.iterate_records(zone)
+                                       if record.name == client_name and record.type == RecordType.MX)
             except StopIteration:
                 # Shouldn't happen, but handle gracefully
                 self.log_warning('MX record exists but could not be found for %s.%s', client_name, zone.domain)
@@ -84,8 +81,8 @@ class SetupMxRecords(_MxRecords):
                     data=MX_RECORD,
                     extra={'priority': 0},
                 )
-                self.log_info('Updated MX records for client %s.%s from %s to %s',
-                             client_name, zone.domain, existing_record.data, MX_RECORD)
+                self.log_info('Updated MX records for client %s.%s from %s to %s', client_name, zone.domain,
+                              existing_record.data, MX_RECORD)
             else:
                 self.log_info('MX records for client %s.%s already exist with correct value', client_name, zone.domain)
         else:

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -16,7 +16,7 @@ WTForms==3.0.1
 email-validator==1.2.1
 Werkzeug==2.2.1
 fasteners==0.17.3
-apache-libcloud==3.6.0
+apache-libcloud==3.2.0
 bcrypt==4.0.1
 beautifulsoup4==4.11.1
 cached-property==1.5.2

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -16,7 +16,7 @@ WTForms==3.0.1
 email-validator==1.2.1
 Werkzeug==2.2.1
 fasteners==0.17.3
-apache-libcloud==3.2.0
+apache-libcloud==3.9.1
 bcrypt==4.0.1
 beautifulsoup4==4.11.1
 cached-property==1.5.2

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -16,7 +16,7 @@ WTForms==3.0.1
 email-validator==1.2.1
 Werkzeug==2.2.1
 fasteners==0.17.3
-apache-libcloud==3.9.1
+apache-libcloud==3.8.0
 bcrypt==4.0.1
 beautifulsoup4==4.11.1
 cached-property==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==2.2.1
 Flask-Cors==3.0.10
 Pillow==10.4.0  # 10.1.0+ required for Python 3.13 support
 setuptools>=65.5.0,<73.0.0  # Required for pkg_resources (gunicorn dependency). setuptools 73+ removed pkg_resources
-apache-libcloud==3.6.0
+apache-libcloud==3.2.0
 applicationinsights==0.11.10
 beautifulsoup4==4.11.1
 cached-property==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==2.2.1
 Flask-Cors==3.0.10
 Pillow==10.4.0  # 10.1.0+ required for Python 3.13 support
 setuptools>=65.5.0,<73.0.0  # Required for pkg_resources (gunicorn dependency). setuptools 73+ removed pkg_resources
-apache-libcloud==3.9.1
+apache-libcloud==3.8.0
 applicationinsights==0.11.10
 beautifulsoup4==4.11.1
 cached-property==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==2.2.1
 Flask-Cors==3.0.10
 Pillow==10.4.0  # 10.1.0+ required for Python 3.13 support
 setuptools>=65.5.0,<73.0.0  # Required for pkg_resources (gunicorn dependency). setuptools 73+ removed pkg_resources
-apache-libcloud==3.2.0
+apache-libcloud==3.9.1
 applicationinsights==0.11.10
 beautifulsoup4==4.11.1
 cached-property==1.5.2

--- a/tests/opwen_email_server/services/test_dns.py
+++ b/tests/opwen_email_server/services/test_dns.py
@@ -101,11 +101,14 @@ class SetupMxRecordsTests(TestCase):
                 Zone(id='1', domain='foo.com', type='master', ttl=1, driver=mock_driver),
                 zone,
             ]
-            
-            existing_record = Record(
-                id='1', name='my-domain', type=RecordType.MX, 
-                data='mx.sendgrid.net', zone=zone, ttl=1, driver=mock_driver
-            )
+
+            existing_record = Record(id='1',
+                                     name='my-domain',
+                                     type=RecordType.MX,
+                                     data='mx.sendgrid.net',
+                                     zone=zone,
+                                     ttl=1,
+                                     driver=mock_driver)
             mock_driver.iterate_records.return_value = [existing_record]
             mock_driver.create_record.side_effect = throw(
                 RecordAlreadyExistsError('record already exists', mock_driver, 'record_id'))
@@ -126,11 +129,14 @@ class SetupMxRecordsTests(TestCase):
                 Zone(id='1', domain='foo.com', type='master', ttl=1, driver=mock_driver),
                 zone,
             ]
-            
-            existing_record = Record(
-                id='1', name='my-domain', type=RecordType.MX, 
-                data='wrong-server.com', zone=zone, ttl=1, driver=mock_driver
-            )
+
+            existing_record = Record(id='1',
+                                     name='my-domain',
+                                     type=RecordType.MX,
+                                     data='wrong-server.com',
+                                     zone=zone,
+                                     ttl=1,
+                                     driver=mock_driver)
             mock_driver.iterate_records.return_value = [existing_record]
             mock_driver.create_record.side_effect = throw(
                 RecordAlreadyExistsError('record already exists', mock_driver, 'record_id'))

--- a/tests/opwen_email_server/services/test_dns.py
+++ b/tests/opwen_email_server/services/test_dns.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from libcloud.common.types import LibcloudError
 from libcloud.dns.base import Record
+from libcloud.dns.types import RecordAlreadyExistsError
 from libcloud.dns.types import RecordType
 from libcloud.dns.base import Zone
 
@@ -91,21 +92,55 @@ class SetupMxRecordsTests(TestCase):
             self.assertEqual(mock_driver.iterate_zones.call_count, 1)
             self.assertEqual(mock_driver.create_record.call_count, 1)
 
-    def test_returns_when_record_already_exists(self):
+    def test_returns_when_record_already_exists_with_correct_value(self):
         action = SetupMxRecords('my-user', 'my-key', provider='CLOUDFLARE')
 
         with patch.object(action, '_driver', new_callable=PropertyMock) as mock_driver:
+            zone = Zone(id='2', domain='my-zone', type='master', ttl=1, driver=mock_driver)
             mock_driver.iterate_zones.return_value = [
                 Zone(id='1', domain='foo.com', type='master', ttl=1, driver=mock_driver),
-                Zone(id='2', domain='my-zone', type='master', ttl=1, driver=mock_driver),
+                zone,
             ]
+            
+            existing_record = Record(
+                id='1', name='my-domain', type=RecordType.MX, 
+                data='mx.sendgrid.net', zone=zone, ttl=1, driver=mock_driver
+            )
+            mock_driver.iterate_records.return_value = [existing_record]
             mock_driver.create_record.side_effect = throw(
-                LibcloudError('81057: The record already exists.', mock_driver))
+                RecordAlreadyExistsError('record already exists', mock_driver, 'record_id'))
 
             action('my-domain.my-zone')
 
             self.assertEqual(mock_driver.iterate_zones.call_count, 1)
             self.assertEqual(mock_driver.create_record.call_count, 1)
+            self.assertEqual(mock_driver.iterate_records.call_count, 1)
+            self.assertEqual(mock_driver.update_record.call_count, 0)  # No update needed
+
+    def test_updates_record_when_it_exists_with_wrong_value(self):
+        action = SetupMxRecords('my-user', 'my-key', provider='CLOUDFLARE')
+
+        with patch.object(action, '_driver', new_callable=PropertyMock) as mock_driver:
+            zone = Zone(id='2', domain='my-zone', type='master', ttl=1, driver=mock_driver)
+            mock_driver.iterate_zones.return_value = [
+                Zone(id='1', domain='foo.com', type='master', ttl=1, driver=mock_driver),
+                zone,
+            ]
+            
+            existing_record = Record(
+                id='1', name='my-domain', type=RecordType.MX, 
+                data='wrong-server.com', zone=zone, ttl=1, driver=mock_driver
+            )
+            mock_driver.iterate_records.return_value = [existing_record]
+            mock_driver.create_record.side_effect = throw(
+                RecordAlreadyExistsError('record already exists', mock_driver, 'record_id'))
+
+            action('my-domain.my-zone')
+
+            self.assertEqual(mock_driver.iterate_zones.call_count, 1)
+            self.assertEqual(mock_driver.create_record.call_count, 1)
+            self.assertEqual(mock_driver.iterate_records.call_count, 1)
+            self.assertEqual(mock_driver.update_record.call_count, 1)  # Should update to correct value
 
     def test_throws_when_error_is_unknown(self):
         action = SetupMxRecords('my-user', 'my-key', provider='CLOUDFLARE')


### PR DESCRIPTION
## Problem

Client registration was failing with `TypeError: __init__() missing 1 required positional argument: 'record_id'` during DNS MX record creation. The error occurred in `apache-libcloud 3.6.0`'s Cloudflare DNS driver when handling errors during record creation.

### Root Cause
- **apache-libcloud 3.6.0** introduced error codes (81057, 81058) with incomplete error handling
- When Cloudflare returns errors during record CREATION (not update), there's no `record_id` in context
- Exception constructors failed requiring `record_id` parameter
- Downgrading to **3.2.0** (last working version) revealed Python 3.12 incompatibility (`ssl.match_hostname` removed)

### Python Version Constraints
- **Server**: Python 3.9 (cannot use libcloud 3.9.0+ which requires Python 3.10+)
- **Client**: Python 3.12+ (requires libcloud 3.8.0+ for compatibility)

## Solution

### 1. Upgrade to apache-libcloud 3.8.0
- ✅ Last version supporting Python 3.9
- ✅ First version supporting Python 3.12 (beta)
- ✅ No Cloudflare DNS parse_error bug

### 2. Refactor DNS Error Handling
- Use type-safe `RecordAlreadyExistsError` instead of string matching on generic `LibcloudError`
- When MX record already exists, verify it points to correct mail server (`mx.sendgrid.net`)
- Automatically update record if it points to wrong server
- Better logging with before/after values on updates

## Changes

- `requirements.txt`: `apache-libcloud==3.6.0` → `apache-libcloud==3.8.0`
- `requirements-webapp.txt`: `apache-libcloud==3.6.0` → `apache-libcloud==3.8.0`
- `opwen_email_server/services/dns.py`:
  - Import `RecordAlreadyExistsError` for type-safe exception handling
  - Add MX record verification when record already exists
  - Add automatic update logic if record points to wrong server
- `tests/opwen_email_server/services/test_dns.py`:
  - Update tests to use `RecordAlreadyExistsError`
  - Add test for record exists with correct value (no update)
  - Add test for record exists with wrong value (updates to correct server)

## Benefits

1. **Fixes registration bug**: Client registration now works correctly
2. **Python compatibility**: Works with both Python 3.9 (server) and 3.12 (client)
3. **Prevents silent failures**: Detects and fixes MX records pointing to wrong mail server
4. **Better error handling**: Type-safe exceptions instead of string matching
5. **Comprehensive tests**: All 8 DNS service tests passing

## Testing

- ✅ All DNS service unit tests passing locally (8/8)
- ✅ CI should pass for both `test-local` (Python 3.12) and `test-server` (Python 3.9)
- 🔄 Ready for smoke testing after merge/deployment