### PR TITLE
fix: Switch from Azure Service Bus to RabbitMQ for task queue

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -7,7 +7,6 @@ x-shared-secret-environment:
     HOST: 0.0.0.0
     WEBAPP_PORT: 8080
     LOKOLE_STORAGE_PROVIDER: AZURE_BLOBS
-    LOKOLE_QUEUE_BROKER_SCHEME: azureservicebus
     CONNEXION_SPEC: dir:/app/opwen_email_server/swagger
     CELERY_QUEUE_NAMES: all
     TESTING_UI: "False"
@@ -44,3 +43,21 @@ services:
     image: ascoderu/opwenserver_app:latest
     command: ["/app/docker/app/run-celery.sh"]
     <<: *shared-secret-environment
+    depends_on:
+      - rabbitmq
+
+  rabbitmq:
+    image: rabbitmq:management-alpine
+    environment:
+      # Use same creds from azure.env for convenience
+      RABBITMQ_DEFAULT_USER: ${LOKOLE_EMAIL_SERVER_QUEUES_SAS_NAME}
+      RABBITMQ_DEFAULT_PASS: ${LOKOLE_EMAIL_SERVER_QUEUES_SAS_KEY}
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    restart: always
+    # Optional: expose management UI
+    # ports:
+    #   - 15672:15672
+
+volumes:
+  rabbitmq_data:

--- a/opwen_email_server/config.py
+++ b/opwen_email_server/config.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from environs import Env
 
 env = Env()
@@ -65,6 +67,9 @@ QUEUE_BROKER_USERNAME = env('LOKOLE_EMAIL_SERVER_QUEUES_SAS_NAME')
 QUEUE_BROKER_PASSWORD = env('LOKOLE_EMAIL_SERVER_QUEUES_SAS_KEY')
 QUEUE_BROKER_HOST = env('LOKOLE_EMAIL_SERVER_QUEUES_NAMESPACE')
 if env('LOKOLE_QUEUE_BROKER_SCHEME', ''):
-    QUEUE_BROKER = f"{QUEUE_BROKER_SCHEME}://{QUEUE_BROKER_USERNAME}:{QUEUE_BROKER_PASSWORD}@{QUEUE_BROKER_HOST}"
+    # URL-encode credentials to handle special characters
+    username = quote(QUEUE_BROKER_USERNAME, safe='')
+    password = quote(QUEUE_BROKER_PASSWORD, safe='')
+    QUEUE_BROKER = f"{QUEUE_BROKER_SCHEME}://{username}:{password}@{QUEUE_BROKER_HOST}"
 else:
     QUEUE_BROKER = env('LOKOLE_QUEUE_BROKER_URL', '')


### PR DESCRIPTION
## Problem

Azure Service Bus is incompatible with Kombu 5.x used by Celery 5.3.6, causing production worker failures with:
- `TypeError: isinstance() arg 2 must be a type or tuple of types`
- `RuntimeError: can't start new thread`

All versions of azure-servicebus 7.x have breaking module structure changes that prevent Kombu from connecting. Exhaustive testing confirmed no combination of azure-servicebus/kombu/celery versions works with Python 3.9.

## Solution

Switch from Azure Service Bus to RabbitMQ for the task queue:
- Remove hardcoded `LOKOLE_QUEUE_BROKER_SCHEME=azureservicebus` from production compose
- Add RabbitMQ service (rabbitmq:management-alpine) 
- Add URL encoding for broker credentials to handle special characters (`/`, `=`, `+`)
- Add `rabbitmq_data` volume for queue persistence
- Worker now depends on RabbitMQ service

## Production Deployment

Add these two lines to `secrets/azure.env` on the production server:
```bash
LOKOLE_QUEUE_BROKER_SCHEME=amqp
LOKOLE_EMAIL_SERVER_QUEUES_NAMESPACE=rabbitmq
```

Existing credentials (`LOKOLE_EMAIL_SERVER_QUEUES_SAS_NAME` and `LOKOLE_EMAIL_SERVER_QUEUES_SAS_KEY`) will be reused for RabbitMQ authentication.

## Testing

✅ Tested locally with RabbitMQ 4.3.1 - worker connects successfully
✅ All 7 queues properly defined as durable (from PR #619)
✅ URL encoding handles special characters in credentials

## Related

- Builds on PR #619 (RabbitMQ 4.0+ compatibility fixes)
- Fixes production worker failures introduced in v0.8.9